### PR TITLE
hl: pin gsxhl and tree-sitter-gsx by version, drop sibling replaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,12 +22,13 @@ verify-generated-styles:
 #
 # The generator is a SEPARATE module (site/hl/gen/go.mod) because tree-sitter
 # is C: keeping it out of gsxui's module is what lets site/main.go keep
-# building CGO_ENABLED=0 into a distroless/static image. It resolves the
-# grammar and highlighter from sibling checkouts via replace directives, so
-# it needs ../tree-sitter-gsx and ../gsxhl next to this repo — nothing else
-# does, including CI and the Docker build, which consume the committed output.
+# building CGO_ENABLED=0 into a distroless/static image. The grammar and
+# highlighter are ordinary version pins fetched with GOPRIVATE — no sibling
+# checkouts required, so this runs from any worktree. Nothing else needs the
+# generator, including CI and the Docker build, which consume the committed
+# output.
 highlight:
-	cd site/hl/gen && go run .
+	cd site/hl/gen && GOPRIVATE=github.com/gsxhq/* go run .
 
 # icons regenerates ui/icon/icon_data.go and ui/icon/icon_defs.go from a
 # local Lucide checkout. See internal/lucidegen and Task 1's brief for the

--- a/site/hl/gen/go.mod
+++ b/site/hl/gen/go.mod
@@ -1,24 +1,21 @@
 // Separate module: this generator links tree-sitter (cgo), which must never
 // reach gsxui's own module — site/main.go builds CGO_ENABLED=0 for a
-// distroless/static image. The replace directives resolve the gsx grammar
-// and highlighter from sibling checkouts; nothing here is needed to build or
-// deploy the site, only to regenerate site/hl/blocks.gen.go.
+// distroless/static image. The grammar and highlighter are ordinary version
+// pins (GOPRIVATE=github.com/gsxhq/*); nothing here is needed to build or
+// deploy the site, only to regenerate site/hl/blocks.gen.go. These were
+// sibling-checkout replace directives once, which made make highlight fail
+// from any worktree lacking the siblings at exactly ../../../../.
 module github.com/gsxhq/gsxui/site/hl/gen
 
 go 1.26.1
 
-require github.com/gsxhq/gsxhl v0.0.0
+require github.com/gsxhq/gsxhl v0.0.0-20260730151208-23ad64a27ac9
 
 require (
-	github.com/gsxhq/tree-sitter-gsx v0.0.0 // indirect
+	github.com/gsxhq/tree-sitter-gsx v0.0.0-20260730150336-81d28e59d472 // indirect
 	github.com/jackielii/go-tree-sitter-highlight v0.1.0 // indirect
 	github.com/mattn/go-pointer v0.0.1 // indirect
 	github.com/tree-sitter/go-tree-sitter v0.25.0 // indirect
 	github.com/tree-sitter/tree-sitter-css v0.25.0 // indirect
 	github.com/tree-sitter/tree-sitter-javascript v0.25.0 // indirect
-)
-
-replace (
-	github.com/gsxhq/gsxhl => ../../../../gsxhl
-	github.com/gsxhq/tree-sitter-gsx => ../../../../tree-sitter-gsx
 )

--- a/site/hl/gen/go.sum
+++ b/site/hl/gen/go.sum
@@ -1,5 +1,9 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gsxhq/gsxhl v0.0.0-20260730151208-23ad64a27ac9 h1:MLX6NkslqCg2+Nwd+zPhgjsiWuIRmT+22FxD1wKOj6o=
+github.com/gsxhq/gsxhl v0.0.0-20260730151208-23ad64a27ac9/go.mod h1:Wy6etWALfgt4ZFGTS3Xy+g9T48liSMQ83jq6XOm3Odo=
+github.com/gsxhq/tree-sitter-gsx v0.0.0-20260730150336-81d28e59d472 h1:vfPje+3xiOg1avwIkdBHYMt0mUZeTCB+TfKBnsFikiA=
+github.com/gsxhq/tree-sitter-gsx v0.0.0-20260730150336-81d28e59d472/go.mod h1:qSbwbMW75hrBcLVztfk3jty07Y3XLTCJEQikdFGDJbI=
 github.com/jackielii/go-tree-sitter-highlight v0.1.0 h1:Xh6K1YuFRX8Ap5zrspyZ0CV5pyCCoG40L0QcyQ5kKwg=
 github.com/jackielii/go-tree-sitter-highlight v0.1.0/go.mod h1:5rIk+j40yfATjPLvbLmJDVdwMs05AjOqTuQ2bAcahyM=
 github.com/mattn/go-pointer v0.0.1 h1:n+XhsuGeVO6MEAp7xyEukFINEa+Quek5psIR/ylA6o0=


### PR DESCRIPTION
## What

Pins the docs highlighter to real versions — `gsxhl@23ad64a` carrying
`tree-sitter-gsx@81d28e5` — and deletes the sibling-checkout `replace`
directives.

## The upgrade

The new grammar injects `css\`` literals as real CSS, gated on a terminated
declaration (tree-sitter-gsx#14). The trailing semicolons the canonical
sources already carry are what satisfy that gate — this is the payoff of
that earlier work. `site/hl/blocks.gen.go` regenerates **bit-identical**:
no doc block contains a css literal yet (blocks come from `site/examples` +
`site/snippets` only), so the injection gains its first consumer when
component sources reach the docs — which the upcoming gallery work brings.

## The structural fix

`replace => ../../../../gsxhl` resolves relative to the checkout. Every
worktree used this month — `/tmp` agents and `.worktrees/` alike — hit
`make highlight` failing on the missing siblings, each time worked around
with symlinks (one wave documented the symlinks not surviving between shell
invocations). With ordinary version pins and `GOPRIVATE` baked into the
make target, the generator now runs from any worktree with no siblings —
verified in this worktree with no `../gsxhl` present.

## Verification

- `make highlight` from a sibling-less worktree: 133 blocks, output
  bit-identical to the committed file.
- `go build ./...`, `go test ./...` (zero failures), `go test ./site/hl`.
- Comments in the Makefile and gen/go.mod updated — both described the
  sibling requirement this removes.

https://claude.ai/code/session_01GJjsg9jx6Cxp5B87A1RnH3
