### PR TITLE
ui: clamp hand-rolled popover positioning to the viewport

### DIFF
--- a/jstest/harness/shim.js
+++ b/jstest/harness/shim.js
@@ -58,3 +58,15 @@ function callerModule() {
   }
   return "unknown";
 }
+
+// clampToViewport is the real implementation, unchanged — positioning is
+// behavior under test, not delegation, so the recording layer must not
+// distort it. Keep in lockstep with ui/gsxui.js ("exact export surface"
+// above): a module importing a name the shim lacks fails to evaluate, and
+// with it every registration this file exists to record.
+export function clampToViewport(content, left, top) {
+  const maxLeft = document.documentElement.clientWidth - content.offsetWidth;
+  const maxTop = document.documentElement.clientHeight - content.offsetHeight;
+  content.style.left = `${Math.max(0, Math.min(left, maxLeft))}px`;
+  content.style.top = `${Math.max(0, Math.min(top, maxTop))}px`;
+}

--- a/jstest/specs/theme-editor.spec.ts
+++ b/jstest/specs/theme-editor.spec.ts
@@ -771,3 +771,22 @@ test("preview rejects state messages with an empty attempt identity", async ({
   await expect(status).toHaveText("Live");
   await expect(retry).toBeHidden();
 });
+
+test("the base-color picker's popover stays inside the viewport", async ({ page }) => {
+  // At the desktop layout the picker column sits at the left edge with a
+  // ~156px trigger; the popover content is 288px wide and centered on the
+  // trigger's midpoint, which computes left = -34px — rendered flush
+  // offscreen-left before clampToViewport existed (reported from a real
+  // session). Asserting x >= 0 discriminates: mid-enter the scale animation
+  // shifts the box inward by ~7px, so the unclamped position still measures
+  // negative.
+  await page.goto("/theme");
+  await expect(page.locator("[data-theme-preview-status]")).toHaveText("Live");
+  const trigger = page.locator('[data-theme-picker="baseColor"] [data-gsxui-slot-popover-trigger]');
+  await trigger.click();
+  const content = page.locator('[data-theme-picker="baseColor"] [data-gsxui-slot-popover-content]');
+  await expect(content).toBeVisible();
+  const box = await content.boundingBox();
+  expect(box, "content has a box").not.toBeNull();
+  expect(box!.x, "left edge inside viewport").toBeGreaterThanOrEqual(0);
+});

--- a/ui/combobox.js
+++ b/ui/combobox.js
@@ -33,27 +33,38 @@
 // command.js — a JS-only import would be invisible to
 // internal/registry.Deps' go/parser scan over the generated .x.go, silently
 // breaking CLI vendoring (see the .gsx file's own GAP entry).
-import { on, emit } from "./gsxui.js";
+import { on, emit, clampToViewport } from "./gsxui.js";
 
 const rootOf = (el) => el.closest("[data-gsxui-slot-combobox]");
-const inputOf = (root) => root?.querySelector("[data-gsxui-slot-combobox-input]") ?? null;
-const contentOf = (root) => root?.querySelector("[data-gsxui-slot-combobox-content]") ?? null;
-const listOf = (root) => root?.querySelector("[data-gsxui-slot-combobox-list]") ?? null;
-const bridgeOf = (root) => root?.querySelector("[data-gsxui-slot-combobox-bridge]") ?? null;
-const itemsOf = (root) => (root ? [...root.querySelectorAll("[data-gsxui-slot-combobox-item]")] : []);
+const inputOf = (root) =>
+  root?.querySelector("[data-gsxui-slot-combobox-input]") ?? null;
+const contentOf = (root) =>
+  root?.querySelector("[data-gsxui-slot-combobox-content]") ?? null;
+const listOf = (root) =>
+  root?.querySelector("[data-gsxui-slot-combobox-list]") ?? null;
+const bridgeOf = (root) =>
+  root?.querySelector("[data-gsxui-slot-combobox-bridge]") ?? null;
+const itemsOf = (root) =>
+  root ? [...root.querySelectorAll("[data-gsxui-slot-combobox-item]")] : [];
 const isDisabled = (item) =>
   item.getAttribute("aria-disabled") === "true" || "disabled" in item.dataset;
 const labelOf = (item) => item.textContent.trim();
-const visibleItems = (root) => itemsOf(root).filter((i) => !i.hidden && !isDisabled(i));
+const visibleItems = (root) =>
+  itemsOf(root).filter((i) => !i.hidden && !isDisabled(i));
 const highlightedOf = (root) =>
-  root?.querySelector('[data-gsxui-slot-combobox-item][data-highlighted="true"]') ?? null;
+  root?.querySelector(
+    '[data-gsxui-slot-combobox-item][data-highlighted="true"]',
+  ) ?? null;
 
 let uid = 0;
 
 // --- filter: Intl.Collator-backed boolean `contains` (Base UI's useFilter
 // default) — the exact algorithm traced from Base UI's docs/issue tracker,
 // mirroring React Aria's own implementation. See the file header ADAPT.
-const collator = new Intl.Collator(undefined, { usage: "search", sensitivity: "base" });
+const collator = new Intl.Collator(undefined, {
+  usage: "search",
+  sensitivity: "base",
+});
 
 function contains(string, substring) {
   if (substring.length === 0) return true;
@@ -107,18 +118,25 @@ function highlight(root, item) {
 // not just the one whose label happens to be sitting in the input).
 function filter(root, queryOverride) {
   const input = inputOf(root);
-  const query = queryOverride !== undefined ? queryOverride : (input?.value ?? "").trim();
+  const query =
+    queryOverride !== undefined ? queryOverride : (input?.value ?? "").trim();
   let any = false;
   for (const item of itemsOf(root)) {
     const match = contains(labelOf(item), query);
     item.hidden = !match;
     if (match) any = true;
   }
-  for (const group of root.querySelectorAll("[data-gsxui-slot-combobox-group]")) {
-    const items = [...group.querySelectorAll("[data-gsxui-slot-combobox-item]")];
+  for (const group of root.querySelectorAll(
+    "[data-gsxui-slot-combobox-group]",
+  )) {
+    const items = [
+      ...group.querySelectorAll("[data-gsxui-slot-combobox-item]"),
+    ];
     group.hidden = items.length > 0 && items.every((i) => i.hidden);
   }
-  for (const sep of root.querySelectorAll("[data-gsxui-slot-combobox-separator]")) {
+  for (const sep of root.querySelectorAll(
+    "[data-gsxui-slot-combobox-separator]",
+  )) {
     sep.hidden = query !== "";
   }
   contentOf(root)?.toggleAttribute("data-empty", !any);
@@ -237,7 +255,9 @@ on("reset", "form:has([data-gsxui-slot-combobox])", (_e, form) => {
 // open/closed state — see ui/combobox.gsx's ComboboxInput doc comment) ----
 
 function init(root) {
-  for (const group of root.querySelectorAll("[data-gsxui-slot-combobox-group]")) {
+  for (const group of root.querySelectorAll(
+    "[data-gsxui-slot-combobox-group]",
+  )) {
     if (group.getAttribute("aria-labelledby")) continue;
     const label = group.querySelector("[data-gsxui-slot-combobox-label]");
     if (!label) continue;
@@ -263,7 +283,9 @@ function init(root) {
   // the exact "reopening filtered to the committed label" bug this flag
   // exists to prevent (see docs/jsx-parity.md `## combobox`'s own FIX
   // entry): every option except this one would stay hidden.
-  const checked = root.querySelector('[data-gsxui-slot-combobox-item][data-state="checked"]');
+  const checked = root.querySelector(
+    '[data-gsxui-slot-combobox-item][data-state="checked"]',
+  );
   if (checked && input) {
     const label = labelOf(checked);
     if (!input.value) input.value = label;
@@ -271,7 +293,8 @@ function init(root) {
   }
 }
 
-for (const root of document.querySelectorAll("[data-gsxui-slot-combobox]")) init(root);
+for (const root of document.querySelectorAll("[data-gsxui-slot-combobox]"))
+  init(root);
 
 // --- open / close (ported dropdown.js/select.js machinery) ---------------
 
@@ -279,13 +302,13 @@ function openContent(root) {
   const content = contentOf(root);
   const input = inputOf(root);
   if (!content || content.matches(":popover-open")) return;
-  const anchor = input?.closest("[data-gsxui-slot-combobox-input-group]") ?? input;
+  const anchor =
+    input?.closest("[data-gsxui-slot-combobox-input-group]") ?? input;
   if (anchor) {
     const r = anchor.getBoundingClientRect();
     content.style.position = "fixed";
     content.style.inset = "auto";
-    content.style.left = `${r.left}px`;
-    content.style.top = `${r.bottom + 4}px`;
+    clampToViewport(content, r.left, r.bottom + 4);
     content.style.minWidth = `${r.width}px`;
   }
   // Stamp open BEFORE showing — the toggle event that also stamps it is a
@@ -307,31 +330,40 @@ function closeContent(root) {
 // expects it present regardless of open/closed state — see
 // ui/combobox.gsx's own ComboboxInput doc comment); this handler only
 // tracks open/closed state and clears the highlight cursor on close.
-on("toggle", "[data-gsxui-slot-combobox-content]", (e, content) => {
-  const open = e.newState === "open";
-  content.dataset.state = open ? "open" : "closed";
-  const root = rootOf(content);
-  const input = inputOf(root);
-  input?.setAttribute("aria-expanded", open ? "true" : "false");
-  if (open) {
-    emit(content, "gsxui:open");
-  } else {
-    input?.removeAttribute("aria-activedescendant");
-    for (const item of itemsOf(root)) delete item.dataset.highlighted;
-    emit(content, "gsxui:close");
-  }
-}, { capture: true });
+on(
+  "toggle",
+  "[data-gsxui-slot-combobox-content]",
+  (e, content) => {
+    const open = e.newState === "open";
+    content.dataset.state = open ? "open" : "closed";
+    const root = rootOf(content);
+    const input = inputOf(root);
+    input?.setAttribute("aria-expanded", open ? "true" : "false");
+    if (open) {
+      emit(content, "gsxui:open");
+    } else {
+      input?.removeAttribute("aria-activedescendant");
+      for (const item of itemsOf(root)) delete item.dataset.highlighted;
+      emit(content, "gsxui:close");
+    }
+  },
+  { capture: true },
+);
 
 // contextmenu inside the listbox is suppressed (dropdown.js/select.js do the
 // same).
-on("contextmenu", "[data-gsxui-slot-combobox-content]", (e) => e.preventDefault());
+on("contextmenu", "[data-gsxui-slot-combobox-content]", (e) =>
+  e.preventDefault(),
+);
 
 // --- trigger button --------------------------------------------------------
 
 on("pointerdown", "[data-gsxui-slot-combobox-trigger]", (_e, trigger) => {
   const content = contentOf(rootOf(trigger));
   if (content) {
-    trigger.dataset.gsxuiWasOpen = content.matches(":popover-open") ? "true" : "false";
+    trigger.dataset.gsxuiWasOpen = content.matches(":popover-open")
+      ? "true"
+      : "false";
   }
 });
 

--- a/ui/context-menu.js
+++ b/ui/context-menu.js
@@ -32,10 +32,9 @@
 //     hidePopover() below only matters for a contextmenu event dispatched
 //     without a preceding pointerdown (e.g. the keyboard Menu key), which
 //     still needs to reposition to the new (keyboard-relative) coordinates.
-//   - CLAMPING (the one deviation from dropdown.js/tooltip.js/popover.js's
-//     own documented no-clamp NOTE): those siblings anchor to a FIXED side
-//     of a known trigger element and accept imprecision near viewport edges
-//     as a stopgap until CSS anchor positioning is Baseline. A context menu
+//   - CLAMPING (context-menu was first; the siblings adopted the same
+//     shift-only clamp through gsxui.js's clampToViewport after the theme
+//     editor rendered a picker popover flush offscreen-left). A context menu
 //     has no such fixed anchor — it opens wherever the cursor was, which
 //     can be arbitrarily close to any edge — so an unclamped menu could
 //     render partially or fully offscreen on an ordinary right-click near
@@ -64,13 +63,16 @@
 import { on, emit } from "./gsxui.js";
 
 const contentOf = (el) =>
-  el.closest("[data-gsxui-slot-context-menu]")?.querySelector("[data-gsxui-slot-context-menu-content]");
+  el
+    .closest("[data-gsxui-slot-context-menu]")
+    ?.querySelector("[data-gsxui-slot-context-menu-content]");
 
 // Any popover=auto menu surface — the top-level content or a nested
 // submenu's own content — wherever a keydown/toggle handler must resolve
 // "which content level is this happening at," picking the NEAREST one via
 // closest().
-const CONTENT_SELECTOR = "[data-gsxui-slot-context-menu-content],[data-gsxui-slot-context-menu-sub-content]";
+const CONTENT_SELECTOR =
+  "[data-gsxui-slot-context-menu-content],[data-gsxui-slot-context-menu-sub-content]";
 const ITEM_SELECTOR =
   "[data-gsxui-slot-context-menu-item]:not([aria-disabled]),[data-gsxui-slot-context-menu-checkbox-item]:not([aria-disabled]),[data-gsxui-slot-context-menu-radio-item]:not([aria-disabled]),[data-gsxui-slot-context-menu-sub-trigger]:not([aria-disabled])";
 
@@ -87,8 +89,14 @@ function ownItems(content) {
 }
 
 const subRootOf = (el) => el.closest("[data-gsxui-slot-context-menu-sub]");
-const subContentOf = (trigger) => subRootOf(trigger)?.querySelector("[data-gsxui-slot-context-menu-sub-content]");
-const subTriggerOf = (content) => subRootOf(content)?.querySelector("[data-gsxui-slot-context-menu-sub-trigger]");
+const subContentOf = (trigger) =>
+  subRootOf(trigger)?.querySelector(
+    "[data-gsxui-slot-context-menu-sub-content]",
+  );
+const subTriggerOf = (content) =>
+  subRootOf(content)?.querySelector(
+    "[data-gsxui-slot-context-menu-sub-trigger]",
+  );
 
 on("contextmenu", "[data-gsxui-slot-context-menu-trigger]", (e, trigger) => {
   const content = contentOf(trigger);
@@ -207,13 +215,18 @@ on("keydown", CONTENT_SELECTOR, (e, content) => {
     return;
   }
   if (e.key === "ArrowRight") {
-    const trigger = e.target.closest("[data-gsxui-slot-context-menu-sub-trigger]");
+    const trigger = e.target.closest(
+      "[data-gsxui-slot-context-menu-sub-trigger]",
+    );
     if (!trigger) return;
     e.preventDefault();
     openSubAndFocusFirst(trigger);
     return;
   }
-  if (e.key === "ArrowLeft" && content.matches("[data-gsxui-slot-context-menu-sub-content]")) {
+  if (
+    e.key === "ArrowLeft" &&
+    content.matches("[data-gsxui-slot-context-menu-sub-content]")
+  ) {
     e.preventDefault();
     const trigger = subTriggerOf(content);
     content.hidePopover();
@@ -229,7 +242,12 @@ on("keydown", CONTENT_SELECTOR, (e, content) => {
   // the intended end (ArrowUp: -1 + -1 = -2, wrapping to the SECOND-to-last
   // item, not the last) — special-case the no-selection start explicitly
   // instead of relying on the wraparound arithmetic to do it by accident.
-  const next = i === -1 ? (dir === 1 ? items[0] : items[items.length - 1]) : items[(i + dir + items.length) % items.length];
+  const next =
+    i === -1
+      ? dir === 1
+        ? items[0]
+        : items[items.length - 1]
+      : items[(i + dir + items.length) % items.length];
   if (next) {
     // Moving keyboard focus to a different item at this same level closes
     // any OTHER open submenu among this level's own sub-triggers — without
@@ -239,7 +257,11 @@ on("keydown", CONTENT_SELECTOR, (e, content) => {
     // sub-trigger by an actual pointer movement already fires pointerout on
     // it, which schedules the same close via the grace-period timer below.
     for (const item of items) {
-      if (item !== next && item.matches("[data-gsxui-slot-context-menu-sub-trigger]") && item.dataset.state === "open") {
+      if (
+        item !== next &&
+        item.matches("[data-gsxui-slot-context-menu-sub-trigger]") &&
+        item.dataset.state === "open"
+      ) {
         closeSub(item);
       }
     }
@@ -249,7 +271,11 @@ on("keydown", CONTENT_SELECTOR, (e, content) => {
 });
 
 on("click", "[data-gsxui-slot-context-menu-item]", (_e, item) => {
-  if (item.getAttribute("aria-disabled") === "true" || "disabled" in item.dataset) return;
+  if (
+    item.getAttribute("aria-disabled") === "true" ||
+    "disabled" in item.dataset
+  )
+    return;
   // Always hide the ROOT content, not item.closest(CONTENT_SELECTOR) — from
   // inside a submenu, that resolves to the SUB-content, closing only the
   // submenu and leaving the root open with the sub-trigger still
@@ -266,7 +292,11 @@ on("click", "[data-gsxui-slot-context-menu-item]", (_e, item) => {
 // onSelect closes unless preventDefault is called; this port simply never
 // closes on a checkbox select).
 on("click", "[data-gsxui-slot-context-menu-checkbox-item]", (_e, item) => {
-  if (item.getAttribute("aria-disabled") === "true" || "disabled" in item.dataset) return;
+  if (
+    item.getAttribute("aria-disabled") === "true" ||
+    "disabled" in item.dataset
+  )
+    return;
   const checked = item.dataset.state !== "checked";
   item.dataset.state = checked ? "checked" : "unchecked";
   item.setAttribute("aria-checked", checked ? "true" : "false");
@@ -277,7 +307,11 @@ on("click", "[data-gsxui-slot-context-menu-checkbox-item]", (_e, item) => {
 // radio group (data-gsxui-slot-context-menu-radio-group scopes the sibling walk — a page
 // may have more than one group), and closes the menu like a plain Item.
 on("click", "[data-gsxui-slot-context-menu-radio-item]", (_e, item) => {
-  if (item.getAttribute("aria-disabled") === "true" || "disabled" in item.dataset) return;
+  if (
+    item.getAttribute("aria-disabled") === "true" ||
+    "disabled" in item.dataset
+  )
+    return;
   const group = item.closest("[data-gsxui-slot-context-menu-radio-group]");
   const siblings = group
     ? [...group.querySelectorAll("[data-gsxui-slot-context-menu-radio-item]")]
@@ -303,7 +337,11 @@ on("click", "[data-gsxui-slot-context-menu-radio-item]", (_e, item) => {
 const HOVERABLE_SELECTOR =
   "[data-gsxui-slot-context-menu-item],[data-gsxui-slot-context-menu-checkbox-item],[data-gsxui-slot-context-menu-radio-item],[data-gsxui-slot-context-menu-sub-trigger]";
 on("pointerover", HOVERABLE_SELECTOR, (_e, item) => {
-  if (item.getAttribute("aria-disabled") === "true" || "disabled" in item.dataset) return;
+  if (
+    item.getAttribute("aria-disabled") === "true" ||
+    "disabled" in item.dataset
+  )
+    return;
   item.focus();
 });
 
@@ -312,7 +350,8 @@ on("pointerover", HOVERABLE_SELECTOR, (_e, item) => {
 // Moving into a DOM-nested (open) submenu doesn't count as leaving — it's
 // still `content.contains(relatedTarget)` true, same guard as hover-card.js.
 on("pointerout", CONTENT_SELECTOR, (e, content) => {
-  if (e.relatedTarget instanceof Element && content.contains(e.relatedTarget)) return;
+  if (e.relatedTarget instanceof Element && content.contains(e.relatedTarget))
+    return;
   if (content.contains(document.activeElement)) content.focus();
 });
 
@@ -357,7 +396,10 @@ function closeSub(trigger) {
 
 function scheduleCloseSub(trigger) {
   clearSubTimer(trigger);
-  subTimers.set(trigger, setTimeout(() => closeSub(trigger), SUB_CLOSE_DELAY));
+  subTimers.set(
+    trigger,
+    setTimeout(() => closeSub(trigger), SUB_CLOSE_DELAY),
+  );
 }
 
 // The keyboard-only open path (ArrowRight / Enter on a focused sub-trigger):
@@ -370,25 +412,47 @@ function openSubAndFocusFirst(trigger) {
   if (content) ownItems(content)[0]?.focus();
 }
 
-on("pointerover", "[data-gsxui-slot-context-menu-sub-trigger]", (_e, trigger) => {
-  if (trigger.getAttribute("aria-disabled") === "true" || "disabled" in trigger.dataset) return;
-  openSub(trigger);
-});
+on(
+  "pointerover",
+  "[data-gsxui-slot-context-menu-sub-trigger]",
+  (_e, trigger) => {
+    if (
+      trigger.getAttribute("aria-disabled") === "true" ||
+      "disabled" in trigger.dataset
+    )
+      return;
+    openSub(trigger);
+  },
+);
 on("pointerout", "[data-gsxui-slot-context-menu-sub-trigger]", (e, trigger) => {
   const root = subRootOf(trigger);
   // Moving from the trigger into its OWN content (the gap between them, or
   // the content itself) is not a leave — same "moved within" guard as
   // hover-card.js's own trigger/content pair.
-  if (root && e.relatedTarget instanceof Element && root.contains(e.relatedTarget)) return;
+  if (
+    root &&
+    e.relatedTarget instanceof Element &&
+    root.contains(e.relatedTarget)
+  )
+    return;
   scheduleCloseSub(trigger);
 });
-on("pointerover", "[data-gsxui-slot-context-menu-sub-content]", (_e, content) => {
-  const trigger = subTriggerOf(content);
-  if (trigger) clearSubTimer(trigger);
-});
+on(
+  "pointerover",
+  "[data-gsxui-slot-context-menu-sub-content]",
+  (_e, content) => {
+    const trigger = subTriggerOf(content);
+    if (trigger) clearSubTimer(trigger);
+  },
+);
 on("pointerout", "[data-gsxui-slot-context-menu-sub-content]", (e, content) => {
   const root = subRootOf(content);
-  if (root && e.relatedTarget instanceof Element && root.contains(e.relatedTarget)) return;
+  if (
+    root &&
+    e.relatedTarget instanceof Element &&
+    root.contains(e.relatedTarget)
+  )
+    return;
   const trigger = subTriggerOf(content);
   if (trigger) scheduleCloseSub(trigger);
 });
@@ -400,7 +464,11 @@ on("pointerout", "[data-gsxui-slot-context-menu-sub-content]", (e, content) => {
 // one opened by hover) would re-focus its first item and steal the hover
 // highlight instead of acting as a close toggle.
 on("click", "[data-gsxui-slot-context-menu-sub-trigger]", (_e, trigger) => {
-  if (trigger.getAttribute("aria-disabled") === "true" || "disabled" in trigger.dataset) return;
+  if (
+    trigger.getAttribute("aria-disabled") === "true" ||
+    "disabled" in trigger.dataset
+  )
+    return;
   if (trigger.dataset.state === "open") {
     closeSub(trigger);
     return;

--- a/ui/dropdown-menu.js
+++ b/ui/dropdown-menu.js
@@ -14,16 +14,19 @@
 // popover closes its nested (DOM-descendant) auto popovers as part of the
 // same platform stack-unwind, so a submenu never needs to be closed by hand
 // when its parent menu closes.
-import { on, emit } from "./gsxui.js";
+import { on, emit, clampToViewport } from "./gsxui.js";
 
 const contentOf = (el) =>
-  el.closest("[data-gsxui-slot-dropdown-menu]")?.querySelector("[data-gsxui-slot-dropdown-menu-content]");
+  el
+    .closest("[data-gsxui-slot-dropdown-menu]")
+    ?.querySelector("[data-gsxui-slot-dropdown-menu-content]");
 
 // Any popover=auto menu surface — the top-level content or a nested
 // submenu's own content — wherever a keydown/toggle handler must resolve
 // "which content level is this happening at," picking the NEAREST one via
 // closest().
-const CONTENT_SELECTOR = "[data-gsxui-slot-dropdown-menu-content],[data-gsxui-slot-dropdown-menu-sub-content]";
+const CONTENT_SELECTOR =
+  "[data-gsxui-slot-dropdown-menu-content],[data-gsxui-slot-dropdown-menu-sub-content]";
 const ITEM_SELECTOR =
   "[data-gsxui-slot-dropdown-menu-item]:not([aria-disabled]),[data-gsxui-slot-dropdown-menu-checkbox-item]:not([aria-disabled]),[data-gsxui-slot-dropdown-menu-radio-item]:not([aria-disabled]),[data-gsxui-slot-dropdown-menu-sub-trigger]:not([aria-disabled])";
 
@@ -40,8 +43,14 @@ function ownItems(content) {
 }
 
 const subRootOf = (el) => el.closest("[data-gsxui-slot-dropdown-menu-sub]");
-const subContentOf = (trigger) => subRootOf(trigger)?.querySelector("[data-gsxui-slot-dropdown-menu-sub-content]");
-const subTriggerOf = (content) => subRootOf(content)?.querySelector("[data-gsxui-slot-dropdown-menu-sub-trigger]");
+const subContentOf = (trigger) =>
+  subRootOf(trigger)?.querySelector(
+    "[data-gsxui-slot-dropdown-menu-sub-content]",
+  );
+const subTriggerOf = (content) =>
+  subRootOf(content)?.querySelector(
+    "[data-gsxui-slot-dropdown-menu-sub-trigger]",
+  );
 
 // A pointerdown on the trigger records whether the menu was open at that
 // instant: popover="auto" light-dismisses on outside pointerdown (the
@@ -49,7 +58,10 @@ const subTriggerOf = (content) => subRootOf(content)?.querySelector("[data-gsxui
 // be closed and a bare toggle would wrongly reopen it.
 on("pointerdown", "[data-gsxui-slot-dropdown-menu-trigger]", (_e, trigger) => {
   const content = contentOf(trigger);
-  if (content) trigger.dataset.gsxuiWasOpen = content.matches(":popover-open") ? "true" : "false";
+  if (content)
+    trigger.dataset.gsxuiWasOpen = content.matches(":popover-open")
+      ? "true"
+      : "false";
 });
 
 on("click", "[data-gsxui-slot-dropdown-menu-trigger]", (_e, trigger) => {
@@ -63,15 +75,15 @@ on("click", "[data-gsxui-slot-dropdown-menu-trigger]", (_e, trigger) => {
     if (content.matches(":popover-open")) content.hidePopover();
     return;
   }
-  if (content.matches(":popover-open")) {     // keyboard activation close path
+  if (content.matches(":popover-open")) {
+    // keyboard activation close path
     content.hidePopover();
     return;
   }
   const r = trigger.getBoundingClientRect();
   content.style.position = "fixed";
   content.style.inset = "auto";
-  content.style.left = `${r.left}px`;
-  content.style.top = `${r.bottom + 4}px`;
+  clampToViewport(content, r.left, r.bottom + 4);
   // Stamp open BEFORE showing: the toggle event that also stamps it is
   // queued as a separate task (spec: "queue a popover toggle event task"),
   // and a paint can land in the gap — one frame of the menu fully visible
@@ -89,10 +101,14 @@ on(
   (e, content) => {
     const open = e.newState === "open";
     content.dataset.state = open ? "open" : "closed";
-    const isSub = content.matches("[data-gsxui-slot-dropdown-menu-sub-content]");
+    const isSub = content.matches(
+      "[data-gsxui-slot-dropdown-menu-sub-content]",
+    );
     const trigger = isSub
       ? subTriggerOf(content)
-      : content.closest("[data-gsxui-slot-dropdown-menu]")?.querySelector("[data-gsxui-slot-dropdown-menu-trigger]");
+      : content
+          .closest("[data-gsxui-slot-dropdown-menu]")
+          ?.querySelector("[data-gsxui-slot-dropdown-menu-trigger]");
     trigger?.setAttribute("aria-expanded", open ? "true" : "false");
     // Sub-trigger's own class keys :open highlighting off data-state (same
     // selector shape DropdownMenuItem's data-variant uses) — the top-level
@@ -135,13 +151,18 @@ on("keydown", CONTENT_SELECTOR, (e, content) => {
     return;
   }
   if (e.key === "ArrowRight") {
-    const trigger = e.target.closest("[data-gsxui-slot-dropdown-menu-sub-trigger]");
+    const trigger = e.target.closest(
+      "[data-gsxui-slot-dropdown-menu-sub-trigger]",
+    );
     if (!trigger) return;
     e.preventDefault();
     openSubAndFocusFirst(trigger);
     return;
   }
-  if (e.key === "ArrowLeft" && content.matches("[data-gsxui-slot-dropdown-menu-sub-content]")) {
+  if (
+    e.key === "ArrowLeft" &&
+    content.matches("[data-gsxui-slot-dropdown-menu-sub-content]")
+  ) {
     e.preventDefault();
     const trigger = subTriggerOf(content);
     content.hidePopover();
@@ -157,7 +178,12 @@ on("keydown", CONTENT_SELECTOR, (e, content) => {
   // the intended end (ArrowUp: -1 + -1 = -2, wrapping to the SECOND-to-last
   // item, not the last) — special-case the no-selection start explicitly
   // instead of relying on the wraparound arithmetic to do it by accident.
-  const next = i === -1 ? (dir === 1 ? items[0] : items[items.length - 1]) : items[(i + dir + items.length) % items.length];
+  const next =
+    i === -1
+      ? dir === 1
+        ? items[0]
+        : items[items.length - 1]
+      : items[(i + dir + items.length) % items.length];
   if (next) {
     // Moving keyboard focus to a different item at this same level closes
     // any OTHER open submenu among this level's own sub-triggers — without
@@ -167,7 +193,11 @@ on("keydown", CONTENT_SELECTOR, (e, content) => {
     // sub-trigger by an actual pointer movement already fires pointerout on
     // it, which schedules the same close via the grace-period timer below.
     for (const item of items) {
-      if (item !== next && item.matches("[data-gsxui-slot-dropdown-menu-sub-trigger]") && item.dataset.state === "open") {
+      if (
+        item !== next &&
+        item.matches("[data-gsxui-slot-dropdown-menu-sub-trigger]") &&
+        item.dataset.state === "open"
+      ) {
         closeSub(item);
       }
     }
@@ -177,7 +207,11 @@ on("keydown", CONTENT_SELECTOR, (e, content) => {
 });
 
 on("click", "[data-gsxui-slot-dropdown-menu-item]", (_e, item) => {
-  if (item.getAttribute("aria-disabled") === "true" || "disabled" in item.dataset) return;
+  if (
+    item.getAttribute("aria-disabled") === "true" ||
+    "disabled" in item.dataset
+  )
+    return;
   // Always hide the ROOT content, not item.closest(CONTENT_SELECTOR) — from
   // inside a submenu, that resolves to the SUB-content, closing only the
   // submenu and leaving the root open with the sub-trigger still
@@ -194,7 +228,11 @@ on("click", "[data-gsxui-slot-dropdown-menu-item]", (_e, item) => {
 // onSelect closes unless preventDefault is called; this port simply never
 // closes on a checkbox select).
 on("click", "[data-gsxui-slot-dropdown-menu-checkbox-item]", (_e, item) => {
-  if (item.getAttribute("aria-disabled") === "true" || "disabled" in item.dataset) return;
+  if (
+    item.getAttribute("aria-disabled") === "true" ||
+    "disabled" in item.dataset
+  )
+    return;
   const checked = item.dataset.state !== "checked";
   item.dataset.state = checked ? "checked" : "unchecked";
   item.setAttribute("aria-checked", checked ? "true" : "false");
@@ -205,7 +243,11 @@ on("click", "[data-gsxui-slot-dropdown-menu-checkbox-item]", (_e, item) => {
 // radio group (data-gsxui-slot-dropdown-menu-radio-group scopes the sibling walk — a page
 // may have more than one group), and closes the menu like a plain Item.
 on("click", "[data-gsxui-slot-dropdown-menu-radio-item]", (_e, item) => {
-  if (item.getAttribute("aria-disabled") === "true" || "disabled" in item.dataset) return;
+  if (
+    item.getAttribute("aria-disabled") === "true" ||
+    "disabled" in item.dataset
+  )
+    return;
   const group = item.closest("[data-gsxui-slot-dropdown-menu-radio-group]");
   const siblings = group
     ? [...group.querySelectorAll("[data-gsxui-slot-dropdown-menu-radio-item]")]
@@ -231,7 +273,11 @@ on("click", "[data-gsxui-slot-dropdown-menu-radio-item]", (_e, item) => {
 const HOVERABLE_SELECTOR =
   "[data-gsxui-slot-dropdown-menu-item],[data-gsxui-slot-dropdown-menu-checkbox-item],[data-gsxui-slot-dropdown-menu-radio-item],[data-gsxui-slot-dropdown-menu-sub-trigger]";
 on("pointerover", HOVERABLE_SELECTOR, (_e, item) => {
-  if (item.getAttribute("aria-disabled") === "true" || "disabled" in item.dataset) return;
+  if (
+    item.getAttribute("aria-disabled") === "true" ||
+    "disabled" in item.dataset
+  )
+    return;
   item.focus();
 });
 
@@ -240,7 +286,8 @@ on("pointerover", HOVERABLE_SELECTOR, (_e, item) => {
 // Moving into a DOM-nested (open) submenu doesn't count as leaving — it's
 // still `content.contains(relatedTarget)` true, same guard as hover-card.js.
 on("pointerout", CONTENT_SELECTOR, (e, content) => {
-  if (e.relatedTarget instanceof Element && content.contains(e.relatedTarget)) return;
+  if (e.relatedTarget instanceof Element && content.contains(e.relatedTarget))
+    return;
   if (content.contains(document.activeElement)) content.focus();
 });
 
@@ -265,8 +312,7 @@ function openSub(trigger) {
   const r = trigger.getBoundingClientRect();
   content.style.position = "fixed";
   content.style.inset = "auto";
-  content.style.left = `${r.right}px`;
-  content.style.top = `${r.top - 4}px`; // -4 offsets the content's own p-1 so the first item's text roughly aligns with the trigger's
+  clampToViewport(content, r.right, r.top - 4); // -4 offsets the content's own p-1 so the first item's text roughly aligns with the trigger's
   // Stamp open BEFORE showing — same flash-avoidance rule as the top-level
   // trigger's own click handler (a queued toggle event can otherwise leave
   // one frame painted in the stale closed state).
@@ -285,7 +331,10 @@ function closeSub(trigger) {
 
 function scheduleCloseSub(trigger) {
   clearSubTimer(trigger);
-  subTimers.set(trigger, setTimeout(() => closeSub(trigger), SUB_CLOSE_DELAY));
+  subTimers.set(
+    trigger,
+    setTimeout(() => closeSub(trigger), SUB_CLOSE_DELAY),
+  );
 }
 
 // The keyboard-only open path (ArrowRight / Enter on a focused sub-trigger):
@@ -298,28 +347,58 @@ function openSubAndFocusFirst(trigger) {
   if (content) ownItems(content)[0]?.focus();
 }
 
-on("pointerover", "[data-gsxui-slot-dropdown-menu-sub-trigger]", (_e, trigger) => {
-  if (trigger.getAttribute("aria-disabled") === "true" || "disabled" in trigger.dataset) return;
-  openSub(trigger);
-});
-on("pointerout", "[data-gsxui-slot-dropdown-menu-sub-trigger]", (e, trigger) => {
-  const root = subRootOf(trigger);
-  // Moving from the trigger into its OWN content (the gap between them, or
-  // the content itself) is not a leave — same "moved within" guard as
-  // hover-card.js's own trigger/content pair.
-  if (root && e.relatedTarget instanceof Element && root.contains(e.relatedTarget)) return;
-  scheduleCloseSub(trigger);
-});
-on("pointerover", "[data-gsxui-slot-dropdown-menu-sub-content]", (_e, content) => {
-  const trigger = subTriggerOf(content);
-  if (trigger) clearSubTimer(trigger);
-});
-on("pointerout", "[data-gsxui-slot-dropdown-menu-sub-content]", (e, content) => {
-  const root = subRootOf(content);
-  if (root && e.relatedTarget instanceof Element && root.contains(e.relatedTarget)) return;
-  const trigger = subTriggerOf(content);
-  if (trigger) scheduleCloseSub(trigger);
-});
+on(
+  "pointerover",
+  "[data-gsxui-slot-dropdown-menu-sub-trigger]",
+  (_e, trigger) => {
+    if (
+      trigger.getAttribute("aria-disabled") === "true" ||
+      "disabled" in trigger.dataset
+    )
+      return;
+    openSub(trigger);
+  },
+);
+on(
+  "pointerout",
+  "[data-gsxui-slot-dropdown-menu-sub-trigger]",
+  (e, trigger) => {
+    const root = subRootOf(trigger);
+    // Moving from the trigger into its OWN content (the gap between them, or
+    // the content itself) is not a leave — same "moved within" guard as
+    // hover-card.js's own trigger/content pair.
+    if (
+      root &&
+      e.relatedTarget instanceof Element &&
+      root.contains(e.relatedTarget)
+    )
+      return;
+    scheduleCloseSub(trigger);
+  },
+);
+on(
+  "pointerover",
+  "[data-gsxui-slot-dropdown-menu-sub-content]",
+  (_e, content) => {
+    const trigger = subTriggerOf(content);
+    if (trigger) clearSubTimer(trigger);
+  },
+);
+on(
+  "pointerout",
+  "[data-gsxui-slot-dropdown-menu-sub-content]",
+  (e, content) => {
+    const root = subRootOf(content);
+    if (
+      root &&
+      e.relatedTarget instanceof Element &&
+      root.contains(e.relatedTarget)
+    )
+      return;
+    const trigger = subTriggerOf(content);
+    if (trigger) scheduleCloseSub(trigger);
+  },
+);
 
 // Click toggles: closed -> open (idempotent-safe, moving focus in, same as
 // ArrowRight — covers touch/no-hover pointer types, which never fire the
@@ -328,7 +407,11 @@ on("pointerout", "[data-gsxui-slot-dropdown-menu-sub-content]", (e, content) => 
 // one opened by hover) would re-focus its first item and steal the hover
 // highlight instead of acting as a close toggle.
 on("click", "[data-gsxui-slot-dropdown-menu-sub-trigger]", (_e, trigger) => {
-  if (trigger.getAttribute("aria-disabled") === "true" || "disabled" in trigger.dataset) return;
+  if (
+    trigger.getAttribute("aria-disabled") === "true" ||
+    "disabled" in trigger.dataset
+  )
+    return;
   if (trigger.dataset.state === "open") {
     closeSub(trigger);
     return;

--- a/ui/gsxui.js
+++ b/ui/gsxui.js
@@ -14,7 +14,11 @@ export function on(type, selector, handler, { capture = false } = {}) {
   if (!handlers) {
     handlers = [];
     registry.set(key, handlers);
-    document.addEventListener(type, (event) => dispatch(handlers, event), capture);
+    document.addEventListener(
+      type,
+      (event) => dispatch(handlers, event),
+      capture,
+    );
   }
   handlers.push({ selector, handler });
 }
@@ -32,4 +36,21 @@ export function emit(el, name, detail) {
   return el.dispatchEvent(
     new CustomEvent(name, { bubbles: true, cancelable: true, detail }),
   );
+}
+
+// clampToViewport clamps a desired fixed-position (left, top) so a box of
+// the element's own offset size stays inside the visual viewport. The
+// siblings' documented no-clamp NOTE accepted edge imprecision as a stopgap
+// until CSS anchor positioning is Baseline; the theme editor's pickers
+// disproved the acceptance — an ordinary panel near the viewport edge
+// rendered its popover flush offscreen-left. Shift-only (no side flip), the
+// same semantics context-menu.js already ships. clientWidth/Height rather
+// than innerWidth/Height: the inner metrics include classic-scrollbar
+// gutters, and clamping against them tucks an edge under the scrollbar.
+// Call AFTER showPopover() — a hidden popover has no layout box.
+export function clampToViewport(content, left, top) {
+  const maxLeft = document.documentElement.clientWidth - content.offsetWidth;
+  const maxTop = document.documentElement.clientHeight - content.offsetHeight;
+  content.style.left = `${Math.max(0, Math.min(left, maxLeft))}px`;
+  content.style.top = `${Math.max(0, Math.min(top, maxTop))}px`;
 }

--- a/ui/hover-card.js
+++ b/ui/hover-card.js
@@ -21,7 +21,7 @@
 //     delayed close — tooltip.js needs none of this, since its content is
 //     never interactive and never receives focus or a hover of its own.
 //   - no arrow (hover-card has none, unlike tooltip's diamond span).
-import { on, emit } from "./gsxui.js";
+import { on, emit, clampToViewport } from "./gsxui.js";
 
 // Radix's own defaults are openDelay 700 / closeDelay 300, but shadcn's
 // site demos all pass openDelay={100} closeDelay={100} — the near-instant
@@ -32,9 +32,13 @@ const CLOSE_DELAY = 100;
 
 const timers = new WeakMap(); // trigger -> pending open/close setTimeout id
 const contentOf = (el) =>
-  el.closest("[data-gsxui-slot-hover-card]")?.querySelector("[data-gsxui-slot-hover-card-content]");
+  el
+    .closest("[data-gsxui-slot-hover-card]")
+    ?.querySelector("[data-gsxui-slot-hover-card-content]");
 const triggerOf = (el) =>
-  el.closest("[data-gsxui-slot-hover-card]")?.querySelector("[data-gsxui-slot-hover-card-trigger]");
+  el
+    .closest("[data-gsxui-slot-hover-card]")
+    ?.querySelector("[data-gsxui-slot-hover-card-trigger]");
 
 function clearTimer(trigger) {
   clearTimeout(timers.get(trigger));
@@ -57,8 +61,11 @@ function show(trigger) {
   // the trigger's bottom edge plus Radix's own 4px sideOffset (hover-
   // card.tsx's default, same value as popover.tsx's — no arrow to clear
   // room for, unlike tooltip's 6px-plus-arrow gap above the trigger).
-  content.style.left = `${r.left + r.width / 2 - content.offsetWidth / 2}px`;
-  content.style.top = `${r.bottom + 4}px`;
+  clampToViewport(
+    content,
+    r.left + r.width / 2 - content.offsetWidth / 2,
+    r.bottom + 4,
+  );
   content.dataset.state = "open";
   emit(content, "gsxui:open");
 }
@@ -74,23 +81,35 @@ function hide(trigger) {
 
 function scheduleShow(trigger) {
   clearTimer(trigger);
-  timers.set(trigger, setTimeout(() => show(trigger), OPEN_DELAY));
+  timers.set(
+    trigger,
+    setTimeout(() => show(trigger), OPEN_DELAY),
+  );
 }
 
 function scheduleHide(trigger) {
   clearTimer(trigger);
-  timers.set(trigger, setTimeout(() => hide(trigger), CLOSE_DELAY));
+  timers.set(
+    trigger,
+    setTimeout(() => hide(trigger), CLOSE_DELAY),
+  );
 }
 
-on("pointerover", "[data-gsxui-slot-hover-card-trigger]", (_e, t) => scheduleShow(t));
-on("pointerout", "[data-gsxui-slot-hover-card-trigger]", (_e, t) => scheduleHide(t));
+on("pointerover", "[data-gsxui-slot-hover-card-trigger]", (_e, t) =>
+  scheduleShow(t),
+);
+on("pointerout", "[data-gsxui-slot-hover-card-trigger]", (_e, t) =>
+  scheduleHide(t),
+);
 on("focusin", "[data-gsxui-slot-hover-card-trigger]", (_e, t) => show(t));
 // Leaving the trigger by keyboard rides the same closeDelay grace as
 // leaving it by pointer (scheduleHide, not an immediate hide) — a Tab press
 // that lands on a focusable child of HoverCardContent must not race the
 // popover closing under it. contentOf/triggerOf both key off the trigger,
 // so the content-side focusin below cancels this exact timer.
-on("focusout", "[data-gsxui-slot-hover-card-trigger]", (_e, t) => scheduleHide(t));
+on("focusout", "[data-gsxui-slot-hover-card-trigger]", (_e, t) =>
+  scheduleHide(t),
+);
 
 // The content itself can hold real interactive children — entering it (by
 // pointer OR by keyboard focus) must cancel any pending close the
@@ -115,7 +134,8 @@ on("pointerout", "[data-gsxui-slot-hover-card-content]", (e, content) => {
   // pointer never left the content's own hit area — same guard as
   // dropdown.js's own content pointerout handler, otherwise every internal
   // move would needlessly churn a schedule/clear pair.
-  if (e.relatedTarget instanceof Element && content.contains(e.relatedTarget)) return;
+  if (e.relatedTarget instanceof Element && content.contains(e.relatedTarget))
+    return;
   const trigger = triggerOf(content);
   if (trigger) scheduleHide(trigger);
 });

--- a/ui/menubar.js
+++ b/ui/menubar.js
@@ -40,7 +40,7 @@
 // pointerover/ArrowRight/click, unlike hover-card's own delayed open.
 //
 // toggle doesn't bubble — capture.
-import { on, emit } from "./gsxui.js";
+import { on, emit, clampToViewport } from "./gsxui.js";
 
 // contentOf resolves a trigger (or anything inside its own MenubarMenu) to
 // THAT menu's own content — scoped by data-gsxui-slot-menubar-menu, the
@@ -48,13 +48,16 @@ import { on, emit } from "./gsxui.js";
 // same "closest content, not closest bar" proximity shape dropdown.js's own
 // contentOf uses for its single trigger/content pair.
 const contentOf = (el) =>
-  el.closest("[data-gsxui-slot-menubar-menu]")?.querySelector("[data-gsxui-slot-menubar-content]");
+  el
+    .closest("[data-gsxui-slot-menubar-menu]")
+    ?.querySelector("[data-gsxui-slot-menubar-content]");
 
 // Any popover=auto menu surface — the top-level content or a nested
 // submenu's own content — wherever a keydown/toggle handler must resolve
 // "which content level is this happening at," picking the NEAREST one via
 // closest().
-const CONTENT_SELECTOR = "[data-gsxui-slot-menubar-content],[data-gsxui-slot-menubar-sub-content]";
+const CONTENT_SELECTOR =
+  "[data-gsxui-slot-menubar-content],[data-gsxui-slot-menubar-sub-content]";
 const ITEM_SELECTOR =
   "[data-gsxui-slot-menubar-item]:not([aria-disabled]),[data-gsxui-slot-menubar-checkbox-item]:not([aria-disabled]),[data-gsxui-slot-menubar-radio-item]:not([aria-disabled]),[data-gsxui-slot-menubar-sub-trigger]:not([aria-disabled])";
 
@@ -71,8 +74,10 @@ function ownItems(content) {
 }
 
 const subRootOf = (el) => el.closest("[data-gsxui-slot-menubar-sub]");
-const subContentOf = (trigger) => subRootOf(trigger)?.querySelector("[data-gsxui-slot-menubar-sub-content]");
-const subTriggerOf = (content) => subRootOf(content)?.querySelector("[data-gsxui-slot-menubar-sub-trigger]");
+const subContentOf = (trigger) =>
+  subRootOf(trigger)?.querySelector("[data-gsxui-slot-menubar-sub-content]");
+const subTriggerOf = (content) =>
+  subRootOf(content)?.querySelector("[data-gsxui-slot-menubar-sub-trigger]");
 
 // --- (a) roving tabindex across MenubarTrigger — ui/toggle-group.js's own model ---
 
@@ -108,7 +113,8 @@ function normalize(bar) {
   const triggers = enabledTriggersOf(bar);
   if (triggers.length) setActiveTrigger(bar, triggers[0]);
 }
-for (const bar of document.querySelectorAll("[data-gsxui-slot-menubar]")) normalize(bar);
+for (const bar of document.querySelectorAll("[data-gsxui-slot-menubar]"))
+  normalize(bar);
 
 // isAnyOpen gates (b) open-follows-hover: a menubar requires an explicit
 // open of the FIRST menu (click/Enter/Space/ArrowDown) — only once one
@@ -140,8 +146,7 @@ function openMenu(trigger) {
   const r = trigger.getBoundingClientRect();
   content.style.position = "fixed";
   content.style.inset = "auto";
-  content.style.left = `${r.left}px`;
-  content.style.top = `${r.bottom + 4}px`;
+  clampToViewport(content, r.left, r.bottom + 4);
   // Stamp open BEFORE showing: the toggle event that also stamps it is
   // queued as a separate task, and a paint can land in the gap — see
   // dropdown.js's own comment on the identical rule.
@@ -174,7 +179,10 @@ function switchBarMenu(trigger, dir) {
 // dropdown.js's own trigger click guard.
 on("pointerdown", "[data-gsxui-slot-menubar-trigger]", (_e, trigger) => {
   const content = contentOf(trigger);
-  if (content) trigger.dataset.gsxuiWasOpen = content.matches(":popover-open") ? "true" : "false";
+  if (content)
+    trigger.dataset.gsxuiWasOpen = content.matches(":popover-open")
+      ? "true"
+      : "false";
 });
 
 on("click", "[data-gsxui-slot-menubar-trigger]", (_e, trigger) => {
@@ -188,7 +196,8 @@ on("click", "[data-gsxui-slot-menubar-trigger]", (_e, trigger) => {
     if (content.matches(":popover-open")) content.hidePopover();
     return;
   }
-  if (content.matches(":popover-open")) {     // keyboard activation close path
+  if (content.matches(":popover-open")) {
+    // keyboard activation close path
     content.hidePopover();
     return;
   }
@@ -256,7 +265,9 @@ on(
     const isSub = content.matches("[data-gsxui-slot-menubar-sub-content]");
     const trigger = isSub
       ? subTriggerOf(content)
-      : content.closest("[data-gsxui-slot-menubar-menu]")?.querySelector("[data-gsxui-slot-menubar-trigger]");
+      : content
+          .closest("[data-gsxui-slot-menubar-menu]")
+          ?.querySelector("[data-gsxui-slot-menubar-trigger]");
     trigger?.setAttribute("aria-expanded", open ? "true" : "false");
     // Unlike dropdown.js (where only a SubTrigger's own class keys :open
     // highlighting off data-state), MenubarTrigger's own class ALSO carries
@@ -309,7 +320,9 @@ on("keydown", CONTENT_SELECTOR, (e, content) => {
   // not the bar's own roving-tabindex entry point a browser/OS shortcut
   // could plausibly intercept).
   if (e.key === "ArrowRight") {
-    const subTrigger = e.target.closest("[data-gsxui-slot-menubar-sub-trigger]");
+    const subTrigger = e.target.closest(
+      "[data-gsxui-slot-menubar-sub-trigger]",
+    );
     if (subTrigger) {
       e.preventDefault();
       openSubAndFocusFirst(subTrigger);
@@ -317,7 +330,9 @@ on("keydown", CONTENT_SELECTOR, (e, content) => {
     }
     if (content.matches("[data-gsxui-slot-menubar-sub-content]")) return; // no meaning for a plain item inside a submenu
     e.preventDefault();
-    const trigger = content.closest("[data-gsxui-slot-menubar-menu]")?.querySelector("[data-gsxui-slot-menubar-trigger]");
+    const trigger = content
+      .closest("[data-gsxui-slot-menubar-menu]")
+      ?.querySelector("[data-gsxui-slot-menubar-trigger]");
     if (trigger) switchBarMenu(trigger, 1);
     return;
   }
@@ -334,7 +349,9 @@ on("keydown", CONTENT_SELECTOR, (e, content) => {
       return;
     }
     e.preventDefault();
-    const trigger = content.closest("[data-gsxui-slot-menubar-menu]")?.querySelector("[data-gsxui-slot-menubar-trigger]");
+    const trigger = content
+      .closest("[data-gsxui-slot-menubar-menu]")
+      ?.querySelector("[data-gsxui-slot-menubar-trigger]");
     if (trigger) switchBarMenu(trigger, -1);
     return;
   }
@@ -347,7 +364,12 @@ on("keydown", CONTENT_SELECTOR, (e, content) => {
   // the intended end (ArrowUp: -1 + -1 = -2, wrapping to the SECOND-to-last
   // item, not the last) — special-case the no-selection start explicitly
   // instead of relying on the wraparound arithmetic to do it by accident.
-  const next = i === -1 ? (dir === 1 ? items[0] : items[items.length - 1]) : items[(i + dir + items.length) % items.length];
+  const next =
+    i === -1
+      ? dir === 1
+        ? items[0]
+        : items[items.length - 1]
+      : items[(i + dir + items.length) % items.length];
   if (next) {
     // Moving keyboard focus to a different item at this same level closes
     // any OTHER open submenu among this level's own sub-triggers — without
@@ -357,7 +379,11 @@ on("keydown", CONTENT_SELECTOR, (e, content) => {
     // sub-trigger by an actual pointer movement already fires pointerout on
     // it, which schedules the same close via the grace-period timer below.
     for (const item of items) {
-      if (item !== next && item.matches("[data-gsxui-slot-menubar-sub-trigger]") && item.dataset.state === "open") {
+      if (
+        item !== next &&
+        item.matches("[data-gsxui-slot-menubar-sub-trigger]") &&
+        item.dataset.state === "open"
+      ) {
         closeSub(item);
       }
     }
@@ -367,7 +393,11 @@ on("keydown", CONTENT_SELECTOR, (e, content) => {
 });
 
 on("click", "[data-gsxui-slot-menubar-item]", (_e, item) => {
-  if (item.getAttribute("aria-disabled") === "true" || "disabled" in item.dataset) return;
+  if (
+    item.getAttribute("aria-disabled") === "true" ||
+    "disabled" in item.dataset
+  )
+    return;
   // Always hide the ROOT content, not item.closest(CONTENT_SELECTOR) — from
   // inside a submenu, that resolves to the SUB-content, closing only the
   // submenu and leaving the root open with the sub-trigger still
@@ -386,7 +416,11 @@ on("click", "[data-gsxui-slot-menubar-item]", (_e, item) => {
 // onSelect closes unless preventDefault is called; this port simply never
 // closes on a checkbox select).
 on("click", "[data-gsxui-slot-menubar-checkbox-item]", (_e, item) => {
-  if (item.getAttribute("aria-disabled") === "true" || "disabled" in item.dataset) return;
+  if (
+    item.getAttribute("aria-disabled") === "true" ||
+    "disabled" in item.dataset
+  )
+    return;
   const checked = item.dataset.state !== "checked";
   item.dataset.state = checked ? "checked" : "unchecked";
   item.setAttribute("aria-checked", checked ? "true" : "false");
@@ -398,7 +432,11 @@ on("click", "[data-gsxui-slot-menubar-checkbox-item]", (_e, item) => {
 // page may have more than one group), and closes the menu like a plain
 // Item.
 on("click", "[data-gsxui-slot-menubar-radio-item]", (_e, item) => {
-  if (item.getAttribute("aria-disabled") === "true" || "disabled" in item.dataset) return;
+  if (
+    item.getAttribute("aria-disabled") === "true" ||
+    "disabled" in item.dataset
+  )
+    return;
   const group = item.closest("[data-gsxui-slot-menubar-radio-group]");
   const siblings = group
     ? [...group.querySelectorAll("[data-gsxui-slot-menubar-radio-item]")]
@@ -424,7 +462,11 @@ on("click", "[data-gsxui-slot-menubar-radio-item]", (_e, item) => {
 const HOVERABLE_SELECTOR =
   "[data-gsxui-slot-menubar-item],[data-gsxui-slot-menubar-checkbox-item],[data-gsxui-slot-menubar-radio-item],[data-gsxui-slot-menubar-sub-trigger]";
 on("pointerover", HOVERABLE_SELECTOR, (_e, item) => {
-  if (item.getAttribute("aria-disabled") === "true" || "disabled" in item.dataset) return;
+  if (
+    item.getAttribute("aria-disabled") === "true" ||
+    "disabled" in item.dataset
+  )
+    return;
   item.focus();
 });
 
@@ -433,7 +475,8 @@ on("pointerover", HOVERABLE_SELECTOR, (_e, item) => {
 // Moving into a DOM-nested (open) submenu doesn't count as leaving — it's
 // still `content.contains(relatedTarget)` true, same guard as hover-card.js.
 on("pointerout", CONTENT_SELECTOR, (e, content) => {
-  if (e.relatedTarget instanceof Element && content.contains(e.relatedTarget)) return;
+  if (e.relatedTarget instanceof Element && content.contains(e.relatedTarget))
+    return;
   if (content.contains(document.activeElement)) content.focus();
 });
 
@@ -458,8 +501,7 @@ function openSub(trigger) {
   const r = trigger.getBoundingClientRect();
   content.style.position = "fixed";
   content.style.inset = "auto";
-  content.style.left = `${r.right}px`;
-  content.style.top = `${r.top - 4}px`; // -4 offsets the content's own p-1 so the first item's text roughly aligns with the trigger's
+  clampToViewport(content, r.right, r.top - 4); // -4 offsets the content's own p-1 so the first item's text roughly aligns with the trigger's
   // Stamp open BEFORE showing — same flash-avoidance rule as the top-level
   // trigger's own openMenu.
   trigger.dataset.state = "open";
@@ -477,7 +519,10 @@ function closeSub(trigger) {
 
 function scheduleCloseSub(trigger) {
   clearSubTimer(trigger);
-  subTimers.set(trigger, setTimeout(() => closeSub(trigger), SUB_CLOSE_DELAY));
+  subTimers.set(
+    trigger,
+    setTimeout(() => closeSub(trigger), SUB_CLOSE_DELAY),
+  );
 }
 
 // The keyboard-only open path (ArrowRight / Enter on a focused sub-trigger):
@@ -491,7 +536,11 @@ function openSubAndFocusFirst(trigger) {
 }
 
 on("pointerover", "[data-gsxui-slot-menubar-sub-trigger]", (_e, trigger) => {
-  if (trigger.getAttribute("aria-disabled") === "true" || "disabled" in trigger.dataset) return;
+  if (
+    trigger.getAttribute("aria-disabled") === "true" ||
+    "disabled" in trigger.dataset
+  )
+    return;
   openSub(trigger);
 });
 on("pointerout", "[data-gsxui-slot-menubar-sub-trigger]", (e, trigger) => {
@@ -499,7 +548,12 @@ on("pointerout", "[data-gsxui-slot-menubar-sub-trigger]", (e, trigger) => {
   // Moving from the trigger into its OWN content (the gap between them, or
   // the content itself) is not a leave — same "moved within" guard as
   // hover-card.js's own trigger/content pair.
-  if (root && e.relatedTarget instanceof Element && root.contains(e.relatedTarget)) return;
+  if (
+    root &&
+    e.relatedTarget instanceof Element &&
+    root.contains(e.relatedTarget)
+  )
+    return;
   scheduleCloseSub(trigger);
 });
 on("pointerover", "[data-gsxui-slot-menubar-sub-content]", (_e, content) => {
@@ -508,7 +562,12 @@ on("pointerover", "[data-gsxui-slot-menubar-sub-content]", (_e, content) => {
 });
 on("pointerout", "[data-gsxui-slot-menubar-sub-content]", (e, content) => {
   const root = subRootOf(content);
-  if (root && e.relatedTarget instanceof Element && root.contains(e.relatedTarget)) return;
+  if (
+    root &&
+    e.relatedTarget instanceof Element &&
+    root.contains(e.relatedTarget)
+  )
+    return;
   const trigger = subTriggerOf(content);
   if (trigger) scheduleCloseSub(trigger);
 });
@@ -520,7 +579,11 @@ on("pointerout", "[data-gsxui-slot-menubar-sub-content]", (e, content) => {
 // one opened by hover) would re-focus its first item and steal the hover
 // highlight instead of acting as a close toggle.
 on("click", "[data-gsxui-slot-menubar-sub-trigger]", (_e, trigger) => {
-  if (trigger.getAttribute("aria-disabled") === "true" || "disabled" in trigger.dataset) return;
+  if (
+    trigger.getAttribute("aria-disabled") === "true" ||
+    "disabled" in trigger.dataset
+  )
+    return;
   if (trigger.dataset.state === "open") {
     closeSub(trigger);
     return;

--- a/ui/navigation-menu.js
+++ b/ui/navigation-menu.js
@@ -65,7 +65,7 @@
 //
 // No Escape/outside-pointerdown light dismiss — same deliberate choice as
 // hover-card.js's own (hover/focus drive it, not outside clicks or Esc).
-import { on, emit } from "./gsxui.js";
+import { on, emit, clampToViewport } from "./gsxui.js";
 
 // NavigationMenuLink variant="trigger" shares the trigger SLOT (presentation)
 // without being a trigger: exclude it so only the real <button> trigger binds.
@@ -73,10 +73,13 @@ const TRIGGER_SELECTOR =
   "[data-gsxui-slot-navigation-menu-trigger]:not([data-gsxui-slot-navigation-menu-link])";
 
 const menuOf = (el) => el.closest("[data-gsxui-slot-navigation-menu]");
-const listOf = (menu) => menu?.querySelector("[data-gsxui-slot-navigation-menu-list]");
+const listOf = (menu) =>
+  menu?.querySelector("[data-gsxui-slot-navigation-menu-list]");
 const itemOf = (el) => el.closest("[data-gsxui-slot-navigation-menu-item]");
 const contentOf = (trigger) =>
-  itemOf(trigger)?.querySelector(":scope > [data-gsxui-slot-navigation-menu-content]");
+  itemOf(trigger)?.querySelector(
+    ":scope > [data-gsxui-slot-navigation-menu-content]",
+  );
 const triggerOf = (content) =>
   itemOf(content)?.querySelector(`:scope > ${TRIGGER_SELECTOR}`);
 
@@ -102,8 +105,7 @@ function isAnyOpen(menu) {
 function positionAt(el, rect, offset) {
   el.style.position = "fixed";
   el.style.inset = "auto";
-  el.style.left = `${rect.left}px`;
-  el.style.top = `${rect.bottom + offset}px`;
+  clampToViewport(el, rect.left, rect.bottom + offset);
 }
 
 function stillWithin(trigger, related) {
@@ -113,7 +115,9 @@ function stillWithin(trigger, related) {
 
 function positionIndicator(menu, trigger) {
   const list = listOf(menu);
-  const indicator = list?.querySelector(":scope > [data-gsxui-slot-navigation-menu-indicator]");
+  const indicator = list?.querySelector(
+    ":scope > [data-gsxui-slot-navigation-menu-indicator]",
+  );
   if (!list || !indicator) return;
   // Radix's own runtime sets position:relative on whatever hosts the
   // indicator's own translate-relative-to inline, at runtime, rather than
@@ -129,7 +133,9 @@ function positionIndicator(menu, trigger) {
 }
 
 function hideIndicator(menu) {
-  const indicator = listOf(menu)?.querySelector(":scope > [data-gsxui-slot-navigation-menu-indicator]");
+  const indicator = listOf(menu)?.querySelector(
+    ":scope > [data-gsxui-slot-navigation-menu-indicator]",
+  );
   if (indicator) indicator.dataset.state = "hidden";
 }
 
@@ -143,8 +149,11 @@ function open(trigger) {
   // Close any OTHER open panel in this menu first — sibling panels are
   // never DOM-nested in one another, so switching is close-then-open, the
   // same shape as menubar.js's own openMenu.
-  for (const other of menu.querySelectorAll("[data-gsxui-slot-navigation-menu-content]")) {
-    if (other !== content && other.matches(":popover-open")) close(triggerOf(other));
+  for (const other of menu.querySelectorAll(
+    "[data-gsxui-slot-navigation-menu-content]",
+  )) {
+    if (other !== content && other.matches(":popover-open"))
+      close(triggerOf(other));
   }
 
   // Positioned under THIS trigger's own rect (viewport={false} semantics —
@@ -194,12 +203,18 @@ function scheduleOpen(trigger) {
     open(trigger);
     return;
   }
-  timers.set(trigger, setTimeout(() => open(trigger), OPEN_DELAY));
+  timers.set(
+    trigger,
+    setTimeout(() => open(trigger), OPEN_DELAY),
+  );
 }
 
 function scheduleClose(trigger) {
   clearTimer(trigger);
-  timers.set(trigger, setTimeout(() => close(trigger), CLOSE_DELAY));
+  timers.set(
+    trigger,
+    setTimeout(() => close(trigger), CLOSE_DELAY),
+  );
 }
 
 on("pointerover", TRIGGER_SELECTOR, (_e, t) => scheduleOpen(t));
@@ -229,10 +244,14 @@ on("click", TRIGGER_SELECTOR, (_e, t) => {
   else open(t);
 });
 
-on("pointerover", "[data-gsxui-slot-navigation-menu-content]", (_e, content) => {
-  const trigger = triggerOf(content);
-  if (trigger) clearTimer(trigger);
-});
+on(
+  "pointerover",
+  "[data-gsxui-slot-navigation-menu-content]",
+  (_e, content) => {
+    const trigger = triggerOf(content);
+    if (trigger) clearTimer(trigger);
+  },
+);
 on("pointerout", "[data-gsxui-slot-navigation-menu-content]", (e, content) => {
   const trigger = triggerOf(content);
   if (!trigger || stillWithin(trigger, e.relatedTarget)) return;

--- a/ui/popover.js
+++ b/ui/popover.js
@@ -7,10 +7,12 @@
 // applies. The one positioning change: centered below the trigger, not
 // left-aligned (Radix's own Popover default is side=bottom align=center;
 // DropdownMenuContent's is align=start). toggle doesn't bubble — capture.
-import { on, emit } from "./gsxui.js";
+import { on, emit, clampToViewport } from "./gsxui.js";
 
 const contentOf = (el) =>
-  el.closest("[data-gsxui-slot-popover]")?.querySelector("[data-gsxui-slot-popover-content]");
+  el
+    .closest("[data-gsxui-slot-popover]")
+    ?.querySelector("[data-gsxui-slot-popover-content]");
 
 // A pointerdown on the trigger records whether the popover was open at that
 // instant: popover="auto" light-dismisses on outside pointerdown (the
@@ -21,11 +23,15 @@ const contentOf = (el) =>
 // from any element opted in with data-gsxui-popover-trigger, the idiom for
 // arbitrary triggers. Component markup does not stamp the role hook: for the
 // family trigger the role is implied by identity.
-const TRIGGER_SELECTOR = "[data-gsxui-popover-trigger],[data-gsxui-slot-popover-trigger]";
+const TRIGGER_SELECTOR =
+  "[data-gsxui-popover-trigger],[data-gsxui-slot-popover-trigger]";
 
 on("pointerdown", TRIGGER_SELECTOR, (_e, trigger) => {
   const content = contentOf(trigger);
-  if (content) trigger.dataset.gsxuiWasOpen = content.matches(":popover-open") ? "true" : "false";
+  if (content)
+    trigger.dataset.gsxuiWasOpen = content.matches(":popover-open")
+      ? "true"
+      : "false";
 });
 
 on("click", TRIGGER_SELECTOR, (_e, trigger) => {
@@ -39,7 +45,8 @@ on("click", TRIGGER_SELECTOR, (_e, trigger) => {
     if (content.matches(":popover-open")) content.hidePopover();
     return;
   }
-  if (content.matches(":popover-open")) {     // keyboard activation close path
+  if (content.matches(":popover-open")) {
+    // keyboard activation close path
     content.hidePopover();
     return;
   }
@@ -62,12 +69,15 @@ on("click", TRIGGER_SELECTOR, (_e, trigger) => {
   // align=center — dropdown.js's left-aligned `r.left` is NOT reused here):
   // left is the trigger's horizontal midpoint minus half the content's own
   // width, so the content straddles the trigger's center the way Radix's
-  // Floating-UI align=center placement would. No viewport-edge clamping is
-  // done, consistent with dropdown.js/tooltip.js's own documented NOTE
-  // (hand-rolled position:fixed anchoring, not Floating-UI's collision-
-  // aware placement — a stopgap until CSS anchor positioning is Baseline).
-  content.style.left = `${r.left + r.width / 2 - content.offsetWidth / 2}px`;
-  content.style.top = `${r.bottom + 4}px`;
+  // Floating-UI align=center placement would. Clamped to the viewport by
+  // clampToViewport (shift-only, no side flip) — the old no-clamp NOTE
+  // accepted edge imprecision until the theme editor rendered a picker
+  // popover flush offscreen-left; see gsxui.js.
+  clampToViewport(
+    content,
+    r.left + r.width / 2 - content.offsetWidth / 2,
+    r.bottom + 4,
+  );
 });
 
 // Focus management, the Radix FocusScope trio popover.js was missing
@@ -93,8 +103,12 @@ on(
   "beforetoggle",
   "[data-gsxui-slot-popover-content]",
   (e, content) => {
-    if (e.newState !== "closed" || !content.contains(document.activeElement)) return;
-    content.closest("[data-gsxui-slot-popover]")?.querySelector(TRIGGER_SELECTOR)?.focus();
+    if (e.newState !== "closed" || !content.contains(document.activeElement))
+      return;
+    content
+      .closest("[data-gsxui-slot-popover]")
+      ?.querySelector(TRIGGER_SELECTOR)
+      ?.focus();
   },
   { capture: true },
 );

--- a/ui/select.js
+++ b/ui/select.js
@@ -17,21 +17,31 @@
 //   - a hidden native <select> FORM BRIDGE, populated from the DOM items at
 //     init and kept in sync (value assignment + a bubbling change event).
 // See docs/jsx-parity.md ## select and ui/select.gsx's header.
-import { on, emit } from "./gsxui.js";
+import { on, emit, clampToViewport } from "./gsxui.js";
 
 const rootOf = (el) => el.closest("[data-gsxui-slot-select]");
-const contentOf = (el) => rootOf(el)?.querySelector("[data-gsxui-slot-select-content]");
-const triggerOf = (el) => rootOf(el)?.querySelector("[data-gsxui-slot-select-trigger]");
-const bridgeOf = (root) => root.querySelector("[data-gsxui-slot-select-bridge]");
-const itemsOf = (content) => [...content.querySelectorAll("[data-gsxui-slot-select-item]")];
+const contentOf = (el) =>
+  rootOf(el)?.querySelector("[data-gsxui-slot-select-content]");
+const triggerOf = (el) =>
+  rootOf(el)?.querySelector("[data-gsxui-slot-select-trigger]");
+const bridgeOf = (root) =>
+  root.querySelector("[data-gsxui-slot-select-bridge]");
+const itemsOf = (content) => [
+  ...content.querySelectorAll("[data-gsxui-slot-select-item]"),
+];
 const isDisabled = (item) =>
   item.getAttribute("aria-disabled") === "true" || "disabled" in item.dataset;
-const enabledItems = (content) => itemsOf(content).filter((i) => !isDisabled(i));
+const enabledItems = (content) =>
+  itemsOf(content).filter((i) => !isDisabled(i));
 const labelOf = (item) =>
-  (item.querySelector("[data-gsxui-slot-select-item-text]") ?? item).textContent.trim();
+  (
+    item.querySelector("[data-gsxui-slot-select-item-text]") ?? item
+  ).textContent.trim();
 const focusedItem = (content) => {
   const a = document.activeElement;
-  return a instanceof Element && content.contains(a) && a.matches("[data-gsxui-slot-select-item]")
+  return a instanceof Element &&
+    content.contains(a) &&
+    a.matches("[data-gsxui-slot-select-item]")
     ? a
     : null;
 };
@@ -85,7 +95,10 @@ function focusItem(item, { scroll = false } = {}) {
       if (other !== item) other.setAttribute("aria-selected", "false");
     }
   }
-  item.setAttribute("aria-selected", item.dataset.state === "checked" ? "true" : "false");
+  item.setAttribute(
+    "aria-selected",
+    item.dataset.state === "checked" ? "true" : "false",
+  );
   item.focus({ preventScroll: true });
   if (scroll) item.scrollIntoView({ block: "nearest" });
 }
@@ -114,8 +127,11 @@ function findMatch(items, search, current) {
   const query = allSame ? norm[0] : norm;
   const start = Math.max(0, current ? items.indexOf(current) : 0);
   let wrapped = items.slice(start).concat(items.slice(0, start));
-  if (query.length === 1 && current) wrapped = wrapped.filter((it) => it !== current);
-  return wrapped.find((it) => labelOf(it).toLowerCase().startsWith(query)) ?? null;
+  if (query.length === 1 && current)
+    wrapped = wrapped.filter((it) => it !== current);
+  return (
+    wrapped.find((it) => labelOf(it).toLowerCase().startsWith(query)) ?? null
+  );
 }
 
 // --- init: bridge population, aria wiring, server-checked reflection -------
@@ -138,7 +154,9 @@ function init(root) {
   const trigger = root.querySelector("[data-gsxui-slot-select-trigger]");
   if (content) {
     // Wire each group's aria-labelledby to its own label's generated id.
-    for (const group of content.querySelectorAll("[data-gsxui-slot-select-group]")) {
+    for (const group of content.querySelectorAll(
+      "[data-gsxui-slot-select-group]",
+    )) {
       if (group.getAttribute("aria-labelledby")) continue;
       const label = group.querySelector("[data-gsxui-slot-select-label]");
       if (!label) continue;
@@ -151,7 +169,8 @@ function init(root) {
     populateBridge(content, bridge);
     // aria-required lives on the combobox trigger; the bridge carries the real
     // required attribute (there is no context to pass it directly to the trigger).
-    if (trigger && bridge.required) trigger.setAttribute("aria-required", "true");
+    if (trigger && bridge.required)
+      trigger.setAttribute("aria-required", "true");
   }
   // Reflect a server-rendered checked item into the trigger text + bridge value.
   const checked = content?.querySelector(
@@ -160,7 +179,8 @@ function init(root) {
   if (checked) applyValue(root, checked, { silent: true });
 }
 
-for (const root of document.querySelectorAll("[data-gsxui-slot-select]")) init(root);
+for (const root of document.querySelectorAll("[data-gsxui-slot-select]"))
+  init(root);
 
 // --- open / close (ported dropdown.js machinery) --------------------------
 
@@ -168,8 +188,7 @@ function openContent(trigger, content) {
   const r = trigger.getBoundingClientRect();
   content.style.position = "fixed";
   content.style.inset = "auto";
-  content.style.left = `${r.left}px`;
-  content.style.top = `${r.bottom + 4}px`;
+  clampToViewport(content, r.left, r.bottom + 4);
   // Popper-equivalent width: never narrower than the trigger (Radix's
   // --radix-select-trigger-width). min-w-36 from the class still floors it.
   content.style.minWidth = `${r.width}px`;
@@ -183,7 +202,9 @@ function openContent(trigger, content) {
 on("pointerdown", "[data-gsxui-slot-select-trigger]", (_e, trigger) => {
   const content = contentOf(trigger);
   if (content) {
-    trigger.dataset.gsxuiWasOpen = content.matches(":popover-open") ? "true" : "false";
+    trigger.dataset.gsxuiWasOpen = content.matches(":popover-open")
+      ? "true"
+      : "false";
   }
 });
 
@@ -243,10 +264,20 @@ on("keydown", "[data-gsxui-slot-select-content]", (e, content) => {
   }
   // Printable char → typeahead. Space is a search char only mid-search;
   // otherwise it falls through to selection below.
-  if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey && !(e.key === " " && buffer === "")) {
+  if (
+    e.key.length === 1 &&
+    !e.ctrlKey &&
+    !e.metaKey &&
+    !e.altKey &&
+    !(e.key === " " && buffer === "")
+  ) {
     e.preventDefault();
     pushSearch(e.key);
-    const match = findMatch(enabledItems(content), buffer, focusedItem(content));
+    const match = findMatch(
+      enabledItems(content),
+      buffer,
+      focusedItem(content),
+    );
     if (match) focusItem(match, { scroll: true });
     return;
   }
@@ -281,7 +312,9 @@ on("keydown", "[data-gsxui-slot-select-content]", (e, content) => {
 });
 
 // contextmenu inside the listbox is suppressed (Radix does the same).
-on("contextmenu", "[data-gsxui-slot-select-content]", (e) => e.preventDefault());
+on("contextmenu", "[data-gsxui-slot-select-content]", (e) =>
+  e.preventDefault(),
+);
 
 // --- keyboard on the CLOSED trigger ---------------------------------------
 
@@ -291,7 +324,13 @@ on("keydown", "[data-gsxui-slot-select-trigger]", (e, trigger) => {
   // Typeahead on the closed trigger selects the value in place (no open),
   // exactly like a native <select>. Space with no active search is an OPEN
   // request, not a search char.
-  if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey && !(e.key === " " && buffer === "")) {
+  if (
+    e.key.length === 1 &&
+    !e.ctrlKey &&
+    !e.metaKey &&
+    !e.altKey &&
+    !(e.key === " " && buffer === "")
+  ) {
     e.preventDefault();
     pushSearch(e.key);
     const current = content.querySelector(
@@ -341,8 +380,10 @@ on("click", "[data-gsxui-slot-select-item]", (_e, item) => {
 // keep working) and clears every item's aria-selected — same shape as
 // dropdown.js's content-level pointerout handler.
 on("pointerout", "[data-gsxui-slot-select-content]", (e, content) => {
-  if (e.relatedTarget instanceof Element && content.contains(e.relatedTarget)) return;
+  if (e.relatedTarget instanceof Element && content.contains(e.relatedTarget))
+    return;
   if (!content.contains(document.activeElement)) return;
-  for (const item of itemsOf(content)) item.setAttribute("aria-selected", "false");
+  for (const item of itemsOf(content))
+    item.setAttribute("aria-selected", "false");
   content.focus();
 });

--- a/ui/tooltip.js
+++ b/ui/tooltip.js
@@ -1,10 +1,12 @@
 // Tooltip: pointerover/out + focusin/out delegation (these bubble), 300ms
 // open delay, manual popover so hover can't light-dismiss it.
-import { on, emit } from "./gsxui.js";
+import { on, emit, clampToViewport } from "./gsxui.js";
 
 const timers = new WeakMap();
 const contentOf = (el) =>
-  el.closest("[data-gsxui-slot-tooltip]")?.querySelector("[data-gsxui-slot-tooltip-content]");
+  el
+    .closest("[data-gsxui-slot-tooltip]")
+    ?.querySelector("[data-gsxui-slot-tooltip-content]");
 
 function show(trigger) {
   const content = contentOf(trigger);
@@ -19,8 +21,11 @@ function show(trigger) {
   // duration — the tooltip would enter at the untranslated spot and snap.
   // offsetWidth/Height are layout sizes, unaffected by the in-flight
   // enter scale.
-  content.style.left = `${r.left + r.width / 2 - content.offsetWidth / 2}px`;
-  content.style.top = `${r.top - 6 - content.offsetHeight}px`;
+  clampToViewport(
+    content,
+    r.left + r.width / 2 - content.offsetWidth / 2,
+    r.top - 6 - content.offsetHeight,
+  );
   content.dataset.state = "open";
   emit(content, "gsxui:open");
 }
@@ -39,11 +44,15 @@ function hide(trigger) {
 // to any element opted in with data-gsxui-tooltip-trigger, the idiom for
 // arbitrary triggers (Sidebar's menu button uses it). Component markup does
 // not stamp the role hook: for the family trigger the role is implied by identity.
-const TRIGGER_SELECTOR = "[data-gsxui-tooltip-trigger],[data-gsxui-slot-tooltip-trigger]";
+const TRIGGER_SELECTOR =
+  "[data-gsxui-tooltip-trigger],[data-gsxui-slot-tooltip-trigger]";
 
 on("pointerover", TRIGGER_SELECTOR, (_e, t) => {
   clearTimeout(timers.get(t));
-  timers.set(t, setTimeout(() => show(t), 300));
+  timers.set(
+    t,
+    setTimeout(() => show(t), 300),
+  );
 });
 on("pointerout", TRIGGER_SELECTOR, (_e, t) => hide(t));
 on("focusin", TRIGGER_SELECTOR, (_e, t) => show(t));


### PR DESCRIPTION
The theme editor's Base color picker rendered its popover flush offscreen-left (user-reported, screenshot-confirmed): a ~156px trigger at the viewport edge, 288px content centered on its midpoint, no bounds check — left = -34px.

`clampToViewport` in gsxui.js shares context-menu.js's proven shift-only clamp with the eight other hand-rolled positioning modules (10 call sites). The old no-clamp NOTE accepted edge imprecision as a stopgap until CSS anchor positioning is Baseline; a first-party panel disproved it. No side-flip — shift only, matching the context-menu precedent; `data-side` animations unaffected.

The harness shim replaces gsxui.js wholesale and must mirror its export surface — a missing export fails module evaluation for every importer (took 127 tests down mid-development; now documented in the shim).

Pin: reproduces the desktop geometry, verified to FAIL with the clamp disabled and pass with it. 424/424 Playwright, Go gates green.

https://claude.ai/code/session_01GJjsg9jx6Cxp5B87A1RnH3