### PR TITLE
test: assert compact codes re-encode canonically after decode

### DIFF
--- a/internal/preset/compact_test.go
+++ b/internal/preset/compact_test.go
@@ -113,6 +113,13 @@ func TestCompactShareRoundTripsEveryCatalogCombination(t *testing.T) {
 					if !presetsEqual(got, value) {
 						t.Fatalf("DecodeShare(%q) = %#v, want %#v", code, got, value)
 					}
+					reencoded, err := EncodeShare(got)
+					if err != nil {
+						t.Fatalf("EncodeShare(DecodeShare(%q)): %v", code, err)
+					}
+					if reencoded != code {
+						t.Fatalf("EncodeShare(DecodeShare(%q)) = %q, want the original code; the catalog is no longer injective", code, reencoded)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Adds the reverse-direction assertion issue #7 asks for: in the exhaustive compact-transport round-trip test, every decoded preset must re-encode to the original code. Today's catalog is injective so this passes; if a future palette alias breaks injectivity, the test fails loudly instead of shipping a silent Go/browser divergence.

Fixes #7

https://claude.ai/code/session_01MnsWTDC2g1dxgvqfDux6nL