### PR TITLE
chore: bump gsx — batched watch refresh (dev regen 26s → 4.6s)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gsxhq/gsxui
 go 1.26.1
 
 require (
-	github.com/gsxhq/gsx v0.0.0-20260730145838-f5d42e1cbb77
+	github.com/gsxhq/gsx v0.0.0-20260812102551-587ef1f8997a
 	github.com/gsxhq/vite v0.3.2
 	github.com/jackielii/structpages v0.6.6
 	github.com/jackielii/tailwind-merge-go v0.0.0-20260726184505-8a911ed0cf9a

--- a/go.sum
+++ b/go.sum
@@ -8,10 +8,8 @@ github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx5
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/gsxhq/gsx v0.0.0-20260728095825-ef72f5eba066 h1:z4lSoRy35RVSgkBNi9vwlBMhiDXqVBCM0Jki0/LkDVM=
-github.com/gsxhq/gsx v0.0.0-20260728095825-ef72f5eba066/go.mod h1:/jf9pgYLIm/iWTHKFDaSvcSXGL9uj8xZlO+nAP7ZeCU=
-github.com/gsxhq/gsx v0.0.0-20260730145838-f5d42e1cbb77 h1:bANbaCFnCepQOrTCUk3QAtPAoFQjRJSlK6i5Ham+9Gs=
-github.com/gsxhq/gsx v0.0.0-20260730145838-f5d42e1cbb77/go.mod h1:/jf9pgYLIm/iWTHKFDaSvcSXGL9uj8xZlO+nAP7ZeCU=
+github.com/gsxhq/gsx v0.0.0-20260812102551-587ef1f8997a h1:ljARYWFuvf5PGk6nk2OFGWDamXIpJzSGe0E8+4M7w5s=
+github.com/gsxhq/gsx v0.0.0-20260812102551-587ef1f8997a/go.mod h1:/jf9pgYLIm/iWTHKFDaSvcSXGL9uj8xZlO+nAP7ZeCU=
 github.com/gsxhq/vite v0.3.2 h1:7gcoJHDow/xlrHG11UKc/bGg9zYtSuWaDCMKpaI0JnI=
 github.com/gsxhq/vite v0.3.2/go.mod h1:tDUvkK2CbjwYex6b5+kHL0tK2vIwS0h3kJQLroxs2PY=
 github.com/jackielii/ctxkey v1.0.1 h1:CcgbR+fQbrzZJWxI/7Ec4EhzUbmTU1sfI1gV7MAgjIg=


### PR DESCRIPTION
Picks up gsxhq/gsx#184 (`587ef1f8`): `gsx dev`'s generate is now linear in module files instead of O(dirs × files) — the watch session batches saved-disk-fact refresh to one atomic call per module per cycle, and sourceview manifest derivation reuses parse facts for unchanged files.

Measured on this module (warm machine):

| Path | Before | After |
|---|---|---|
| Cold `gsx dev` startup → server up | 21.4s | ~3s |
| One-line `.go` edit → reopen generate | 25.6s | 4.6s |

Verified under the new pin: `GSXCACHE=off go tool gsx generate` reports everything up to date (output byte-identical to committed `.x.go`), and `go build ./site` succeeds.

https://claude.ai/code/session_01L1mQ6U9FmGWT5bp14RtGwK